### PR TITLE
fix premature ack when data file is full

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 tests/data/wasm/*/target
 heaptrack.*
 massif.*
+.idea
 
 # tilt
 tilt_modules/

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -103,10 +103,10 @@ impl<T> InMemoryBufferable for T where
 /// An item that can be buffered.
 ///
 /// This supertrait serves as the base trait for any item that can be pushed into a buffer.
-pub trait Bufferable: InMemoryBufferable + Encodable {}
+pub trait Bufferable: InMemoryBufferable + Encodable + Clone {}
 
 // Blanket implementation for anything that is already bufferable.
-impl<T> Bufferable for T where T: InMemoryBufferable + Encodable {}
+impl<T> Bufferable for T where T: InMemoryBufferable + Encodable + Clone {}
 
 pub trait EventCount {
     fn event_count(&self) -> usize;

--- a/lib/vector-buffers/src/variants/disk_v2/tests/known_errors.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/known_errors.rs
@@ -700,7 +700,7 @@ async fn reader_throws_error_when_record_is_undecodable_via_metadata() {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     struct ControllableRecord(u8);
 
     impl Encodable for ControllableRecord {


### PR DESCRIPTION
This PR is to fix premature ack when event is not written in disk but acknowledged.
RCA: ack works when event (all copy of) is finally dropped i.e. goes out of scope from code i.e. in destructor.
when writing to disk, encoding of event consumes the event and drops ,which trigger destructor and ack.
when current data file is full encoding happens but write fail with exception (which caller retries) but this has caused ack to prematurely happen.

Fix: hold a copy of event which will stop ack. if every things went fine both copy are dropped and event is acked.
if there was data file file return the copy to be tried again.


Testing Done:
added to unit test
1: that in case of DataFileFull error ack do not happen. i.e. listener do not complete
2: in case of write happen successfully ack happen.

Note: I am not sure what would be the performance implication of cloning the object if any.