### PR TITLE
retry s3 request and when observing ConstructionFailure

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -1,0 +1,3 @@
+This lists custom changes merged in Databrcks fork of Vector.
+1. Fix premature ack when data file is full. https://github.com/databricks/vector/pull/1
+2. Retry s3 request even when observing ConstructionFailure to avoid data loss. https://github.com/databricks/vector/pull/2

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -42,7 +42,7 @@ static RETRIABLE_CODES: OnceLock<RegexSet> = OnceLock::new();
 pub fn is_retriable_error<T>(error: &SdkError<T>) -> bool {
     match error {
         SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => true,
-        SdkError::ConstructionFailure(_) => false,
+        SdkError::ConstructionFailure(_) => true,
         SdkError::ResponseError(err) => check_response(err.raw()),
         SdkError::ServiceError(err) => check_response(err.raw()),
         _ => {


### PR DESCRIPTION
we have see data loss when, s3 request creation encounter some intermitted issue with IMDS.
in that case request building was failed with ConstructionFailure and since that in notRetryable data was dropped.

<img width="1528" alt="Screenshot 2024-03-11 at 12 54 13 PM" src="https://github.com/databricks/vector/assets/90670783/83cfdfe1-b4f9-4da3-9f4e-2a757244d8ae">

in this PR we are making ConstructionFailure a retryable error to improve this intermittent completeness issue.