### PR TITLE
Update with new send event logs

### DIFF
--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -64,6 +64,7 @@ impl RequestBuilder<(S3PartitionKey, Vec<Event>)> for S3RequestOptions {
         let metadata = S3Metadata {
             partition_key,
             s3_key: s3_key_prefix,
+            count: events.len(),
             finalizers,
         };
 
@@ -103,8 +104,18 @@ impl RequestBuilder<(S3PartitionKey, Vec<Event>)> for S3RequestOptions {
 
         s3metadata.s3_key = format_s3_key(&s3metadata.s3_key, &filename, &extension);
 
+        let body = payload.into_payload();
+
+        info!(
+            message = "Sending events.",
+            bytes = ?body.len(),
+            events_len = ?s3metadata.count,
+            blob = ?s3metadata.s3_key,
+            container = ?self.bucket,
+        );
+
         S3Request {
-            body: payload.into_payload(),
+            body: body,
             bucket: self.bucket.clone(),
             metadata: s3metadata,
             request_metadata,

--- a/src/sinks/azure_blob/request_builder.rs
+++ b/src/sinks/azure_blob/request_builder.rs
@@ -82,7 +82,7 @@ impl RequestBuilder<(String, Vec<Event>)> for AzureBlobRequestOptions {
 
         let blob_data = payload.into_payload();
 
-        debug!(
+        info!(
             message = "Sending events.",
             bytes = ?blob_data.len(),
             events_len = ?azure_metadata.count,

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -48,6 +48,7 @@ impl MetaDescriptive for S3Request {
 pub struct S3Metadata {
     pub partition_key: S3PartitionKey,
     pub s3_key: String,
+    pub count: usize,
     pub finalizers: EventFinalizers,
 }
 


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Adding sending events log to aws_s3 (upgrading that and azure_blob log to INFO)

Keeping the same format as the existing azure_blob logs (bucket -> container, s3_key -> blob)

Tested with load tests in `dev-azure-koreacentral` + `dev-aws-us-west-2`.

Seeing INFO logs now

AWS
<img width="1693" alt="Screenshot 2024-04-04 at 10 48 45 AM" src="https://github.com/databricks/vector/assets/107439812/2a659681-2def-41eb-bd9a-140d72841686">


Azure
<img width="1710" alt="Screenshot 2024-04-02 at 6 13 47 PM" src="https://github.com/databricks/vector/assets/107439812/d2f95dee-9827-48a1-b08f-a1b206467cbc">

Comparison of logs between azure/aws (left/right respectively)

<img width="1697" alt="Screenshot 2024-04-02 at 6 21 29 PM" src="https://github.com/databricks/vector/assets/107439812/dd041ad4-e445-4a2c-9f76-f536c899e0d4">
