### PR TITLE
Update sink handling to retry more exceptions

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -1,3 +1,5 @@
-This lists custom changes merged in Databrcks fork of Vector.
+This lists custom changes merged in Databricks fork of Vector.
 1. Fix premature ack when data file is full. https://github.com/databricks/vector/pull/1
 2. Retry s3 request even when observing ConstructionFailure to avoid data loss. https://github.com/databricks/vector/pull/2
+3. Updating/adding INFO logs for when vector sends to cloud storage. https://github.com/databricks/vector/pull/5
+4. Allow retries on all sink exceptions https://github.com/databricks/vector/pull/7

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -82,7 +82,7 @@ fn check_response(res: &HttpResponse) -> bool {
     //
     // Now just look for those when it's a client_error
     let re = RETRIABLE_CODES.get_or_init(|| {
-        RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException"])
+        RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException", "ExpiredToken"])
             .expect("invalid regex")
     });
 

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -107,6 +107,8 @@ mod redis;
 #[cfg(feature = "transforms-reduce")]
 mod reduce;
 mod remap;
+#[cfg(all(feature = "aws-core", feature = "sinks-azure_blob"))]
+mod retries;
 mod sample;
 #[cfg(feature = "sinks-sematext")]
 mod sematext_metrics;
@@ -241,6 +243,8 @@ pub(crate) use self::redis::*;
 pub(crate) use self::reduce::*;
 #[cfg(feature = "transforms-remap")]
 pub(crate) use self::remap::*;
+#[cfg(all(feature = "aws-core", feature = "sinks-azure_blob"))]
+pub(crate) use self::retries::*;
 #[cfg(feature = "transforms-impl-sample")]
 pub(crate) use self::sample::*;
 #[cfg(feature = "sinks-sematext")]

--- a/src/internal_events/retries.rs
+++ b/src/internal_events/retries.rs
@@ -1,0 +1,22 @@
+use metrics::counter;
+use vector_lib::internal_event::InternalEvent;
+
+#[derive(Debug)]
+pub struct CheckRetryEvent<'a> {
+    pub status_code: &'a str,
+    pub retry: bool,
+}
+
+impl InternalEvent for CheckRetryEvent<'_> {
+    fn emit(self) {
+        debug!(
+            message = "Considering retry on error.",
+            status_code = self.status_code,
+            retry = self.retry,
+        );
+        counter!("sink_retries_total", 1,
+            "status_code" => self.status_code.to_string(),
+            "retry" => self.retry.to_string(),
+        );
+    }
+}

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -194,3 +194,29 @@ pub fn build_client(
     }
     Ok(std::sync::Arc::new(client))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::{
+        StatusCode, BytesStream, Response,
+        error::HttpError,
+        headers::Headers,
+    };
+
+    #[tokio::test]
+    async fn test_retriable() {
+        // Create dummy response
+        // For now, specify only status code for testing
+        // BadRequest (400) should retry
+        let response = Response::new(
+            StatusCode::BadRequest,
+            Headers::new(),
+            Box::pin(BytesStream::new("test"))
+        );
+        let error = HttpError::new(response).await;
+        assert!(
+            AzureBlobRetryLogic.is_retriable_error(&error)
+        );
+    }
+}

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -59,9 +59,12 @@ impl RetryLogic for AzureBlobRetryLogic {
     type Error = HttpError;
     type Response = AzureBlobResponse;
 
-    fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        error.status().is_server_error()
-            || StatusCode::TOO_MANY_REQUESTS.as_u16() == Into::<u16>::into(error.status())
+    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+        // For now, retry request in all cases
+
+        // error.status().is_server_error()
+        //     || StatusCode::TOO_MANY_REQUESTS.as_u16() == Into::<u16>::into(error.status())
+        true
     }
 }
 

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -16,6 +16,7 @@ use vector_lib::{
 
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
+    internal_events::{CheckRetryEvent},
     sinks::{util::retries::RetryLogic, Healthcheck},
 };
 
@@ -59,11 +60,15 @@ impl RetryLogic for AzureBlobRetryLogic {
     type Error = HttpError;
     type Response = AzureBlobResponse;
 
-    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+    fn is_retriable_error(&self, error: &Self::Error) -> bool {
         // For now, retry request in all cases
 
         // error.status().is_server_error()
         //     || StatusCode::TOO_MANY_REQUESTS.as_u16() == Into::<u16>::into(error.status())
+        emit!(CheckRetryEvent {
+            status_code: error.error_code().unwrap_or(""),
+            retry: true,
+        });
         true
     }
 }

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -65,11 +65,18 @@ impl RetryLogic for AzureBlobRetryLogic {
 
         // error.status().is_server_error()
         //     || StatusCode::TOO_MANY_REQUESTS.as_u16() == Into::<u16>::into(error.status())
+        let retry = true;
+        info!(
+            message = "Considered retry on error.",
+            error = %error,
+            retry = retry,
+        );
+
         emit!(CheckRetryEvent {
             status_code: error.error_code().unwrap_or(""),
-            retry: true,
+            retry: retry,
         });
-        true
+        retry
     }
 }
 

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -315,6 +315,12 @@ impl RetryLogic for S3RetryLogic {
 
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         let retry = is_retriable_error(error);
+        info!(
+            message = "Considered retry on error.",
+            error = %error,
+            retry = retry,
+        );
+
         emit!(CheckRetryEvent {
             status_code: error.code().unwrap_or(""),
             retry: retry,

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -15,7 +15,7 @@ use vector_lib::configurable::configurable_component;
 
 use super::service::{S3Response, S3Service};
 use crate::{
-    aws::{create_client, is_retriable_error, AwsAuthentication, RegionOrEndpoint},
+    aws::{create_client, AwsAuthentication, RegionOrEndpoint},
     common::s3::S3ClientBuilder,
     config::ProxyConfig,
     http::status,
@@ -311,8 +311,11 @@ impl RetryLogic for S3RetryLogic {
     type Error = SdkError<PutObjectError, HttpResponse>;
     type Response = S3Response;
 
-    fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        is_retriable_error(error)
+    fn is_retriable_error(&self, _error: &Self::Error) -> bool {
+        // For now, retry request in all cases
+
+        // is_retriable_error(error)
+        true
     }
 }
 

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -193,12 +193,14 @@ where
                     );
                     Some(self.build_retry())
                 } else {
+                    // For now, retry request in all cases
                     error!(
-                        message = "Unexpected error type; dropping the request.",
+                        // message = "Unexpected error type; dropping the request.",
+                        message = "Unexpected error type encountered.",
                         %error,
                         internal_log_rate_limit = true
                     );
-                    None
+                    Some(self.build_retry())
                 }
             }
         }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Updating sink retry logic. For now, make it accept anything, but can eventually tune it for the specific issues that pop up to upstream

Added unit tests, which test two issues that we want to retry

104 (connection reset) request that can't be properly cast for Azure ([ELK](https://kibana-azure-eastus2.staging.cloud.databricks.com/app/discover#/?_a=(columns:!(level,loggerCategory,messageText,shardName,tags.subDir,workspaceId),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:c5287020-08fa-11eb-b2b3-a75007d24823,key:tags.subDir,negate:!f,params:(query:vector-aggregator),type:phrase),query:(match_phrase:(tags.subDir:vector-aggregator)))),index:c5287020-08fa-11eb-b2b3-a75007d24823,interval:auto,query:(language:kuery,query:%22ERROR%22),sort:!())&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))))

400 Bad Request due to token expiration ([ELK](https://kibana-aws-us-west-2.staging.cloud.databricks.com/app/discover#/?_a=(columns:!(level,loggerCategory,messageText,shardName,tags.subDir,workspaceId),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'5c7796e0-2917-11eb-8970-6fda9525d0a8',key:tags.subDir,negate:!f,params:(query:vector-aggregator),type:phrase),query:(match_phrase:(tags.subDir:vector-aggregator)))),index:'5c7796e0-2917-11eb-8970-6fda9525d0a8',interval:auto,query:(language:kuery,query:%22ERROR%22),sort:!())&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4d,to:now))))

Also double-checked with load test
