### PR TITLE
Add AccessDenied to AWS Retry modes

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -3,3 +3,4 @@ This lists custom changes merged in Databricks fork of Vector.
 2. Retry s3 request even when observing ConstructionFailure to avoid data loss. https://github.com/databricks/vector/pull/2
 3. Updating/adding INFO logs for when vector sends to cloud storage. https://github.com/databricks/vector/pull/5
 4. Allow retries on all sink exceptions https://github.com/databricks/vector/pull/7
+5. Also allowing retries on AccessDenied exceptions in AWS https://github.com/databricks/vector/pull/12

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -82,7 +82,7 @@ fn check_response(res: &HttpResponse) -> bool {
     //
     // Now just look for those when it's a client_error
     let re = RETRIABLE_CODES.get_or_init(|| {
-        RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException", "ExpiredToken"])
+        RegexSet::new(["RequestTimeout", "RequestExpired", "ThrottlingException", "ExpiredToken", "AccessDenied"])
             .expect("invalid regex")
     });
 


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Retry on AccessDenied based off recent error