### PR TITLE
Add new uploaded event log

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -5,3 +5,4 @@ This lists custom changes merged in Databricks fork of Vector.
 4. Allow retries on all sink exceptions https://github.com/databricks/vector/pull/7
 5. Also allowing retries on AccessDenied exceptions in AWS https://github.com/databricks/vector/pull/12
 6. Updating version to also carry a Databricks version https://github.com/databricks/vector/pull/13
+7. Add a new event for successful upload to cloud storage (+ rework old send) https://github.com/databricks/vector/pull/14

--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         util::{
             metadata::RequestMetadataBuilder, request_builder::EncodeResult, Compression,
-            RequestBuilder,
+            RequestBuilder, vector_event::VectorSendEventMetadata,
         },
     },
 };
@@ -106,13 +106,12 @@ impl RequestBuilder<(S3PartitionKey, Vec<Event>)> for S3RequestOptions {
 
         let body = payload.into_payload();
 
-        info!(
-            message = "Sending events.",
-            bytes = ?body.len(),
-            events_len = ?s3metadata.count,
-            blob = ?s3metadata.s3_key,
-            container = ?self.bucket,
-        );
+        VectorSendEventMetadata {
+            bytes: body.len(),
+            events_len: s3metadata.count,
+            blob: s3metadata.s3_key.clone(),
+            container: self.bucket.clone(),
+        }.emit_sending_event();
 
         S3Request {
             body: body,

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -17,7 +17,7 @@ use vector_lib::{
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_events::{CheckRetryEvent},
-    sinks::{util::retries::RetryLogic, Healthcheck},
+    sinks::{util::{retries::RetryLogic, vector_event::VectorSendEventMetadata}, Healthcheck},
 };
 
 #[derive(Debug, Clone)]
@@ -48,6 +48,7 @@ impl MetaDescriptive for AzureBlobRequest {
 #[derive(Clone, Debug)]
 pub struct AzureBlobMetadata {
     pub partition_key: String,
+    pub container_name: String,
     pub count: usize,
     pub byte_size: JsonSize,
     pub finalizers: EventFinalizers,
@@ -85,6 +86,8 @@ pub struct AzureBlobResponse {
     pub inner: PutBlockBlobResponse,
     pub events_byte_size: GroupedCountByteSize,
     pub byte_size: usize,
+    // Extending S3 response with additional information relevant for vector send event logs
+    pub send_event_metadata: VectorSendEventMetadata,
 }
 
 impl DriverResponse for AzureBlobResponse {

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -26,6 +26,7 @@ pub mod udp;
 #[cfg(all(any(feature = "sinks-socket", feature = "sinks-statsd"), unix))]
 pub mod unix;
 pub mod uri;
+pub mod vector_event;
 pub mod zstd;
 
 use std::borrow::Cow;

--- a/src/sinks/util/vector_event.rs
+++ b/src/sinks/util/vector_event.rs
@@ -1,0 +1,36 @@
+// Structs used for our vector event logs
+
+// Struct for vector send events (sending, uploaded)
+#[derive(Clone, Debug)]
+pub struct VectorSendEventMetadata {
+    pub bytes: usize,
+    pub events_len: usize,
+    pub blob: String,
+    pub container: String,
+}
+
+impl VectorSendEventMetadata {
+    pub fn emit_upload_event(&self) {
+        info!(
+            message = "Uploaded events.",
+            bytes = self.bytes,
+            events_len = self.events_len,
+            blob = self.blob,
+            container = self.container,
+            // VECTOR_UPLOADED_MESSAGES_EVENT
+            vector_event_type = 4
+        );
+    }
+
+    pub fn emit_sending_event(&self) {
+        info!(
+            message = "Sending events.",
+            bytes = self.bytes,
+            events_len = self.events_len,
+            blob = self.blob,
+            container = self.container,
+            // VECTOR_SENDING_MESSAGES_EVENT
+            vector_event_type = 3
+        );
+    }
+}


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

Adding a new spot for event log emission ([see this portion of the code map doc for specifics on where in the architecture this change is](https://docs.google.com/document/d/1F18DIeQ_32jND_uiCoY__EsDQuPm6mvqVKmdz1qxbjQ/edit#heading=h.5omlamvl459b))

**Testing**
Unit tests pass

Ran load tests in `dev-aws-us-west-2` and `dev-azure-westus` ([sample logs here](https://temp.corp.databricks.com/?e38c458c5cb72d52#Hk6bPttqjbcUPHER4XrG4H9PMmn5BN1Wrxst8PV51eK1))

Also confirmed proto results by decoding output from internal_logs_transformed_proto ([result](https://temp.corp.databricks.com/?2bbda8c3b3086ead#6NbL6oj1sHuNdAW7KfjZ3NRsqYFsi1CAjP3fsA591Y9Z))

Ran another load test with bucket name changed to something invalid, seeing first event log but not the new one (confirmed it only emits when successful)
<img width="1594" alt="Screenshot 2024-06-06 at 4 53 28 PM" src="https://github.com/databricks/vector/assets/107439812/d4aecf30-0d03-4510-8868-4dd12fe6629a">

Just successful send at the moment, error event logs aren't as easy to set up as the error structs themselves aren't easily modified to carry relevant info (definitions are in library code), and we do already have logs + metrics for these errors ([from here](https://github.com/databricks/vector/commit/150a8909f3be1a716ada74a69a656506040c6e7a))