### PR TITLE
use lower of configure timeout and time till midnight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10017,7 +10017,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vector"
-version = "0.37.1-databricks-v1"
+version = "0.37.1-databricks-v2"
 dependencies = [
  "apache-avro",
  "approx",
@@ -10476,6 +10476,7 @@ name = "vector-stream"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "chrono",
  "futures 0.3.30",
  "futures-util",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.37.1-databricks-v1"
+version = "0.37.1-databricks-v2"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"

--- a/README.databricks.md
+++ b/README.databricks.md
@@ -5,3 +5,4 @@ This lists custom changes merged in Databricks fork of Vector.
 4. Allow retries on all sink exceptions https://github.com/databricks/vector/pull/7
 5. Also allowing retries on AccessDenied exceptions in AWS https://github.com/databricks/vector/pull/12
 6. Updating version to also carry a Databricks version https://github.com/databricks/vector/pull/13
+7. Use sink timeout as minimum of time till midnight or configured timeout https://github.com/databricks/vector/pull/15

--- a/lib/vector-core/src/time.rs
+++ b/lib/vector-core/src/time.rs
@@ -21,6 +21,11 @@ pub trait KeyedTimer<K> {
     /// If the given key already exists in the timer, the underlying subtimer is reset.
     fn insert(&mut self, item_key: K);
 
+    /// Insert a new subtimer, keyed by `K` and with a maximum delay.
+    /// expiration delay would be the minimum of the configured delay and supplied max_delay.
+    /// If the given key already exists in the timer, the underlying subtimer is reset.
+    fn insert_with_max_delay(&mut self, item_key: K, max_delay: std::time::Duration);
+
     /// Removes a subtimer from the list.
     fn remove(&mut self, item_key: &K);
 

--- a/lib/vector-stream/Cargo.toml
+++ b/lib/vector-stream/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+chrono.workspace = true
 async-stream = { version = "0.3.5", default-features = false }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.29", default-features = false, features = ["std"] }


### PR DESCRIPTION
when key_prefix in sync have `date=%F` at mid night a new batch is started and old batch stop getting new data.
if old batch is not full (due to size) it will wait for timeout secs before it is uploaded.
till then it keeps the underlying disk buffer files. since all disk buffer for a sink is shared and behave as a sequential tape and ack pointer does not move (because previous day buffer is not uploaded) it hold all requests in disk buffer even some recent batch have been uploaded. a disk buffer full trigger block in full and request timeout happens.


in this PR we set the batch timeout to either configured 180s or close to midnight (midnight + 10 sec) which ever is lower. this flushes the previous day buffer quickly and do not cause disk buffer full and blocking and request timeout due to that.

tested in staging-aws-us-west-2-general1 with manual deployment. no midnight drop seen.

<img width="1664" alt="Screenshot 2024-05-31 at 9 56 49 AM" src="https://github.com/databricks/vector/assets/90670783/b08ef8e7-6dec-47b5-bfbb-466635c3bc49">



logs 
<img width="1391" alt="Screenshot 2024-05-31 at 10 08 18 AM" src="https://github.com/databricks/vector/assets/90670783/fb32a598-0857-4183-ad78-5825740698fc">

