### PR TITLE
Vector event logging for new topology events.

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -6,3 +6,4 @@ This lists custom changes merged in Databricks fork of Vector.
 5. Also allowing retries on AccessDenied exceptions in AWS https://github.com/databricks/vector/pull/12
 6. Updating version to also carry a Databricks version https://github.com/databricks/vector/pull/13
 7. Add a new event for successful upload to cloud storage (+ rework old send) https://github.com/databricks/vector/pull/14
+8. Add new Vector events for topology events (new source/sink creation, vector start/stop) https://github.com/databricks/vector/pull/17

--- a/src/app.rs
+++ b/src/app.rs
@@ -170,6 +170,14 @@ impl Application {
         let (runtime, app) =
             Self::prepare_start(extra_context).unwrap_or_else(|code| std::process::exit(code));
 
+        info!(
+            message = "Started Vector instance.",
+            container = self.container,
+            // VECTOR_SERVICE_EVENT
+            vector_event_type = 2,
+            // VECTOR_PROCESS_START
+            service_event = 1
+        );
         runtime.block_on(app.run())
     }
 
@@ -402,6 +410,16 @@ impl FinishedApplication {
             topology_controller,
             internal_topologies,
         } = self;
+
+        // Emit a vector event indicating the shutdown.
+        info!(
+            message = "Shutting down Vector instance.",
+            container = self.container,
+            // VECTOR_SERVICE_EVENT
+            vector_event_type = 2,
+            // VECTOR_PROCESS_TERMINATION_SIGNAL_RECEIVED
+            service_event = 4
+        );
 
         // At this point, we'll have the only reference to the shared topology controller and can
         // safely remove it from the wrapper to shut down the topology.

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -351,6 +351,17 @@ impl<'a> Builder<'a> {
             let server = async move {
                 debug!("Source starting.");
 
+                info!(
+                    message = "Started source: " + %source.inner.get_component_name(),
+                    container = self.container,
+                    // VECTOR_SERVICE_EVENT
+                    vector_event_type = 2,
+                    // VECTOR_PROCESS_SOURCE_CREATED
+                    service_event = 2,
+                    component_id = %key.id(),
+                    component_type = %source.inner.get_component_name(),
+                );
+
                 let mut result = select! {
                     biased;
 
@@ -589,6 +600,17 @@ impl<'a> Builder<'a> {
 
             let sink = async move {
                 debug!("Sink starting.");
+
+                info!(
+                    message = "Started sink: " + %sink.inner.get_component_name(),
+                    container = self.container,
+                    // VECTOR_SERVICE_EVENT
+                    vector_event_type = 2,
+                    // VECTOR_PROCESS_SINK_CREATED
+                    service_event = 3,
+                    component_id = %key.id(),
+                    component_type = %sink.inner.get_component_name(),
+                );
 
                 // Why is this Arc<Mutex<Option<_>>> needed you ask.
                 // In case when this function build_pieces errors


### PR DESCRIPTION
Adds new event logging for 4 planned Vector event types:
* Vector start.
* Vector termination.
* Creation of a new source (once per instance per source).
* Creation of a new sink (once per instance per sink).

Follow-up PR to consume the new INFO logs in Vector transforms to follow in `universe`.