### PR TITLE
fix(gcp sink): Provide an option to override content encoding for GCP Cloud Storage Sink

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -7,3 +7,4 @@ This lists custom changes merged in Databricks fork of Vector.
 6. Updating version to also carry a Databricks version https://github.com/databricks/vector/pull/13
 7. Add a new event for successful upload to cloud storage (+ rework old send) https://github.com/databricks/vector/pull/14
 8. Add new Vector events for topology events (new source/sink creation, vector start/stop) https://github.com/databricks/vector/pull/17
+9. Provide an option to not set the Content-Encoding header for files uploaded by Google Cloud Storage sink https://github.com/databricks/vector/pull/30

--- a/README.databricks.md
+++ b/README.databricks.md
@@ -7,4 +7,4 @@ This lists custom changes merged in Databricks fork of Vector.
 6. Updating version to also carry a Databricks version https://github.com/databricks/vector/pull/13
 7. Add a new event for successful upload to cloud storage (+ rework old send) https://github.com/databricks/vector/pull/14
 8. Add new Vector events for topology events (new source/sink creation, vector start/stop) https://github.com/databricks/vector/pull/17
-9. Provide an option to not set the Content-Encoding header for files uploaded by Google Cloud Storage sink https://github.com/databricks/vector/pull/30
+9. Provide an option to override the Content-Encoding header for files uploaded by Google Cloud Storage sink https://github.com/databricks/vector/pull/30

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -576,14 +576,15 @@ mod tests {
     }
 
     #[test]
-    fn gcs_build_request_set_content_encoding() {
-        let request = build_request(None, false, Compression::gzip_default(), true);
+    fn gcs_build_request_respect_set_content_encoding_option() {
+        let compression_scheme = Compression::gzip_default();
+        let request = build_request(None, false, compression_scheme, true);
         assert_eq!(
             request.settings.content_encoding,
-            HeaderValue::from_str(Compression::gzip_default().content_encoding().unwrap()).ok()
+            HeaderValue::from_str(compression_scheme.content_encoding().unwrap()).ok()
         );
 
-        let request = build_request(None, false, Compression::gzip_default(), false);
+        let request = build_request(None, false, compression_scheme, false);
         assert!(request.settings.content_encoding.is_none());
     }
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
## Overview

This PR provides an option to override content encoding for objects uploaded to GCP Cloud Storage.
This breaks piping the uploaded objects to downstream systems such as Hadoop Filesystems, which don't work well with ".gzip" file with "content-encoding" header enabled. 

Refer to this [bug](https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/66) for further details

## Test Plan
Added unit tests
```
$ rustfmt src/sinks/gcp/cloud_storage.rs
$ cargo test --color=always  --package vector --lib sinks::gcp::cloud_storage
$ cargo build
```

Canaried the change (w/o content_encoding == "") to Vector Aggregator and made sure files can still be uploaded to GCS with content_encoding header populated.

<img width="529" alt="image" src="https://github.com/user-attachments/assets/6fd69785-74d4-4c89-a075-74a81d2219a2">

Canaried the change (with content_encoding == "") to Vector Aggregator and verified that files no longer have content_encoding header populated.

<img width="543" alt="image" src="https://github.com/user-attachments/assets/7ee51c39-a58a-4aae-a82d-77f3609d6d34">

Canaried the change (with set_content_encoding == "") to staging Vector Aggregator in GCP and verified that Shadow Service Request Logs are now available on Lumberjack:
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/1f78099e-497a-4534-9880-6703a1c317c2">



