### PR TITLE
Propagates the log topic through to the Vector send event.

### DIFF
--- a/src/sinks/aws_s3/sink.rs
+++ b/src/sinks/aws_s3/sink.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         util::{
             metadata::RequestMetadataBuilder, request_builder::EncodeResult, Compression,
-            RequestBuilder, vector_event::VectorSendEventMetadata,
+            RequestBuilder, vector_event::VectorSendEventMetadata, vector_event::extract_topic_name,
         },
     },
 };
@@ -105,12 +105,14 @@ impl RequestBuilder<(S3PartitionKey, Vec<Event>)> for S3RequestOptions {
         s3metadata.s3_key = format_s3_key(&s3metadata.s3_key, &filename, &extension);
 
         let body = payload.into_payload();
+        let topic_name = extract_topic_name(&s3metadata.s3_key);
 
         VectorSendEventMetadata {
             bytes: body.len(),
             events_len: s3metadata.count,
             blob: s3metadata.s3_key.clone(),
             container: self.bucket.clone(),
+            topic: topic_name,
         }.emit_sending_event();
 
         S3Request {

--- a/src/sinks/azure_blob/request_builder.rs
+++ b/src/sinks/azure_blob/request_builder.rs
@@ -12,7 +12,7 @@ use crate::{
         azure_common::config::{AzureBlobMetadata, AzureBlobRequest},
         util::{
             metadata::RequestMetadataBuilder, request_builder::EncodeResult, Compression,
-            RequestBuilder, vector_event::VectorSendEventMetadata,
+            RequestBuilder, vector_event::VectorSendEventMetadata, vector_event::extract_topic_name,
         },
     },
 };
@@ -82,12 +82,14 @@ impl RequestBuilder<(String, Vec<Event>)> for AzureBlobRequestOptions {
         );
 
         let blob_data = payload.into_payload();
+        let topic_name = extract_topic_name(&azure_metadata.partition_key);
 
         VectorSendEventMetadata {
             bytes: blob_data.len(),
             events_len: azure_metadata.count,
             blob: azure_metadata.partition_key.clone(),
             container: self.container_name.clone(),
+            topic: topic_name,
         }.emit_sending_event();
 
         AzureBlobRequest {

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -12,6 +12,7 @@ use tracing::Instrument;
 use crate::sinks::{
     azure_common::config::{AzureBlobRequest, AzureBlobResponse},
     util::vector_event::VectorSendEventMetadata,
+    util::vector_event::extract_topic_name,
 };
 
 #[derive(Clone)]
@@ -51,12 +52,14 @@ impl Service<AzureBlobRequest> for AzureBlobService {
                 Some(encoding) => blob.content_encoding(encoding),
                 None => blob,
             };
+            let topic_name = extract_topic_name(&request.metadata.partition_key);
 
             let send_event_metadata = VectorSendEventMetadata {
                 bytes: byte_size,
                 events_len: request.metadata.count,
                 blob: request.metadata.partition_key.clone(),
                 container: request.metadata.container_name.clone(),
+                topic: topic_name,
             };
 
             let result = blob

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -18,7 +18,10 @@ use vector_lib::stream::DriverResponse;
 use super::config::S3Options;
 use super::partitioner::S3PartitionKey;
 
-use crate::sinks::util::vector_event::VectorSendEventMetadata;
+use crate::sinks::{
+    util::vector_event::VectorSendEventMetadata,
+    util::vector_event::extract_topic_name,
+};
 
 #[derive(Debug, Clone)]
 pub struct S3Request {
@@ -127,12 +130,14 @@ impl Service<S3Request> for S3Service {
         let events_byte_size = request
             .request_metadata
             .into_events_estimated_json_encoded_byte_size();
+            let topic_name = extract_topic_name(&request.metadata.s3_key);
 
         let send_event_metadata = VectorSendEventMetadata {
             bytes: request.body.len(),
             events_len: request.metadata.count,
             blob: request.metadata.s3_key.clone(),
             container: request.bucket.clone(),
+            topic: topic_name,
         };
 
         let client = self.client.clone();

--- a/src/sinks/util/vector_event.rs
+++ b/src/sinks/util/vector_event.rs
@@ -1,4 +1,5 @@
 // Structs used for our vector event logs
+use regex::Regex;
 
 // Struct for vector send events (sending, uploaded)
 #[derive(Clone, Debug)]
@@ -7,6 +8,7 @@ pub struct VectorSendEventMetadata {
     pub events_len: usize,
     pub blob: String,
     pub container: String,
+    pub topic: String,
 }
 
 impl VectorSendEventMetadata {
@@ -17,6 +19,7 @@ impl VectorSendEventMetadata {
             events_len = self.events_len,
             blob = self.blob,
             container = self.container,
+            topic = self.topic,
             // VECTOR_UPLOADED_MESSAGES_EVENT
             vector_event_type = 4
         );
@@ -29,8 +32,41 @@ impl VectorSendEventMetadata {
             events_len = self.events_len,
             blob = self.blob,
             container = self.container,
+            topic = self.topic,
             // VECTOR_SENDING_MESSAGES_EVENT
             vector_event_type = 3
         );
+    }
+}
+
+// Utility function for extracting the topic name from an archived log file path.
+pub fn extract_topic_name(file_path: &str) -> String {
+    // Topic: If the file being uploaded matches the archived-log filepattern we can extract
+    // its topic from said pattern; otherwise propagate the empty-string.
+    let topic_regex = Regex::new(r"archived-log\/log-sync-internal\/([a-zA-Z\/]+)\/date").unwrap();
+    let topic_capture = topic_regex.captures(file_path);
+    if !topic_capture.is_none() {
+        return topic_capture.unwrap()[1].to_string();
+        
+    }
+    return "".to_string();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_topic_name_success() {
+        let file_path = "databricks-logs/archived-log/log-sync-internal/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
+        assert_eq!(extract_topic_name(file_path), "test-topic");
+        let file_path_structured = "databricks-logs/archived-log/log-sync-internal/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
+        assert_eq!(extract_topic_name(file_path_structured), "structured-log/test-topic");
+    }
+
+    #[test]
+    fn extract_topic_name_fail() {
+        let file_path = r"no-topic";
+        assert_eq!(extract_topic_name(file_path), "");
     }
 }

--- a/src/sinks/util/vector_event.rs
+++ b/src/sinks/util/vector_event.rs
@@ -43,7 +43,7 @@ impl VectorSendEventMetadata {
 pub fn extract_topic_name(file_path: &str) -> String {
     // Topic: If the file being uploaded matches the archived-log filepattern we can extract
     // its topic from said pattern; otherwise propagate the empty-string.
-    let topic_regex = Regex::new(r"archived-log\/log-sync-internal\/([a-zA-Z\/]+)\/date").unwrap();
+    let topic_regex = Regex::new(r"archived-log\/log-sync-internal\/([a-zA-Z-_\/]+)\/date").unwrap();
     let topic_capture = topic_regex.captures(file_path);
     if !topic_capture.is_none() {
         return topic_capture.unwrap()[1].to_string();
@@ -60,7 +60,7 @@ mod tests {
     fn extract_topic_name_success() {
         let file_path = "databricks-logs/archived-log/log-sync-internal/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
         assert_eq!(extract_topic_name(file_path), "test-topic");
-        let file_path_structured = "databricks-logs/archived-log/log-sync-internal/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
+        let file_path_structured = "databricks-logs/archived-log/log-sync-internal/structured-log/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
         assert_eq!(extract_topic_name(file_path_structured), "structured-log/test-topic");
     }
 

--- a/src/sinks/util/vector_event.rs
+++ b/src/sinks/util/vector_event.rs
@@ -43,7 +43,7 @@ impl VectorSendEventMetadata {
 pub fn extract_topic_name(file_path: &str) -> String {
     // Topic: If the file being uploaded matches the archived-log filepattern we can extract
     // its topic from said pattern; otherwise propagate the empty-string.
-    let topic_regex = Regex::new(r"archived-log\/log-sync-internal\/([a-zA-Z-_\/]+)\/date").unwrap();
+    let topic_regex = Regex::new(r"archived-log\/log-sync-internal\/(?:structured-log\/)?([a-zA-Z-_]+)\/date").unwrap();
     let topic_capture = topic_regex.captures(file_path);
     if !topic_capture.is_none() {
         return topic_capture.unwrap()[1].to_string();
@@ -61,7 +61,7 @@ mod tests {
         let file_path = "databricks-logs/archived-log/log-sync-internal/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
         assert_eq!(extract_topic_name(file_path), "test-topic");
         let file_path_structured = "databricks-logs/archived-log/log-sync-internal/structured-log/test-topic/date=2024-04-02/us-west-2/vector-aggregator-0/test.log";
-        assert_eq!(extract_topic_name(file_path_structured), "structured-log/test-topic");
+        assert_eq!(extract_topic_name(file_path_structured), "test-topic");
     }
 
     #[test]


### PR DESCRIPTION
Adds a new util method for extracting the topic name from the log file upload pattern; adds it to the vector event log (so it can be propagated to the event log table).

The new util method is tested with a new unit test:
```
% cargo test extract_topic_name     
   Compiling vector v0.39.0-databricks-v1 (/Users/ken.lin/vector)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 24.00s
     Running unittests src/lib.rs (target/debug/deps/vector-b8c6a62aa94e6d9a)

running 2 tests
test sinks::util::vector_event::tests::extract_topic_name_fail ... ok
test sinks::util::vector_event::tests::extract_topic_name_success ... ok
```