### PR TITLE
Add granularity fields for vector

### DIFF
--- a/README.databricks.md
+++ b/README.databricks.md
@@ -8,3 +8,5 @@ This lists custom changes merged in Databricks fork of Vector.
 7. Add a new event for successful upload to cloud storage (+ rework old send) https://github.com/databricks/vector/pull/14
 8. Add new Vector events for topology events (new source/sink creation, vector start/stop) https://github.com/databricks/vector/pull/17
 9. Provide an option to override the Content-Encoding header for files uploaded by Google Cloud Storage sink https://github.com/databricks/vector/pull/30
+10. Add functionality to derive topic from file upload path https://github.com/databricks/vector/pull/33
+11. Update event logs to support emitting granular upload events https://github.com/databricks/vector/pull/35

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -208,7 +208,7 @@ impl S3SinkConfig {
             // Returns back the same result so it continues to work downstream
             .map_result(|result: Result<S3Response, _>| {
                 if let Ok(ref response) = result {
-                    response.send_event_metadata.emit_upload_event();
+                    response.event_log_metadata.emit_upload_event();
                 }
                 result
             })

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -218,7 +218,7 @@ impl AzureBlobSinkConfig {
             // Returns back the same result so it continues to work downstream
             .map_result(|result: StdResult<AzureBlobResponse, _>| {
                 if let Ok(ref response) = result {
-                    response.send_event_metadata.emit_upload_event();
+                    response.event_log_metadata.emit_upload_event();
                 }
                 result
             })

--- a/src/sinks/azure_blob/request_builder.rs
+++ b/src/sinks/azure_blob/request_builder.rs
@@ -12,7 +12,8 @@ use crate::{
         azure_common::config::{AzureBlobMetadata, AzureBlobRequest},
         util::{
             metadata::RequestMetadataBuilder, request_builder::EncodeResult, Compression,
-            RequestBuilder, vector_event::VectorSendEventMetadata, vector_event::extract_topic_name,
+            RequestBuilder,
+            vector_event::{VectorEventLogSendMetadata, generate_count_map}
         },
     },
 };
@@ -48,12 +49,27 @@ impl RequestBuilder<(String, Vec<Event>)> for AzureBlobRequestOptions {
     ) -> (Self::Metadata, RequestMetadataBuilder, Self::Events) {
         let (partition_key, mut events) = input;
         let finalizers = events.take_finalizers();
+
+        // Create event metadata here as this is where the list of events are available pre-encoding
+        // And we want to access this list to process the raw events to see specific field values
+        let event_log_metadata = VectorEventLogSendMetadata {
+            // Events are not encoded here yet, so byte size is not yet known
+            // Setting as 0 here and updating when it is set in build_request()
+            bytes: 0,
+            events_len: events.len(),
+            // Similarly the exact blob isn't determined here yet
+            blob: "".to_string(),
+            container: self.container_name.clone(),
+            count_map: generate_count_map(&events),
+        };
+
         let azure_metadata = AzureBlobMetadata {
             partition_key,
             container_name: self.container_name.clone(),
             count: events.len(),
             byte_size: events.estimated_json_encoded_size_of(),
             finalizers,
+            event_log_metadata: event_log_metadata,
         };
 
         let builder = RequestMetadataBuilder::from_events(&events);
@@ -82,15 +98,11 @@ impl RequestBuilder<(String, Vec<Event>)> for AzureBlobRequestOptions {
         );
 
         let blob_data = payload.into_payload();
-        let topic_name = extract_topic_name(&azure_metadata.partition_key);
 
-        VectorSendEventMetadata {
-            bytes: blob_data.len(),
-            events_len: azure_metadata.count,
-            blob: azure_metadata.partition_key.clone(),
-            container: self.container_name.clone(),
-            topic: topic_name,
-        }.emit_sending_event();
+        // Update some components of the metadata since they've been computed now
+        azure_metadata.event_log_metadata.bytes = blob_data.len();
+        azure_metadata.event_log_metadata.blob = azure_metadata.partition_key.clone();
+        azure_metadata.event_log_metadata.emit_sending_event();
 
         AzureBlobRequest {
             blob_data,

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -17,7 +17,7 @@ use vector_lib::{
 use crate::{
     event::{EventFinalizers, EventStatus, Finalizable},
     internal_events::{CheckRetryEvent},
-    sinks::{util::{retries::RetryLogic, vector_event::VectorSendEventMetadata}, Healthcheck},
+    sinks::{util::{retries::RetryLogic, vector_event::VectorEventLogSendMetadata}, Healthcheck},
 };
 
 #[derive(Debug, Clone)]
@@ -52,6 +52,8 @@ pub struct AzureBlobMetadata {
     pub count: usize,
     pub byte_size: JsonSize,
     pub finalizers: EventFinalizers,
+    // Specify additional information relevant for vector send event logs
+    pub event_log_metadata: VectorEventLogSendMetadata,
 }
 
 #[derive(Debug, Clone)]
@@ -86,8 +88,8 @@ pub struct AzureBlobResponse {
     pub inner: PutBlockBlobResponse,
     pub events_byte_size: GroupedCountByteSize,
     pub byte_size: usize,
-    // Extending S3 response with additional information relevant for vector send event logs
-    pub send_event_metadata: VectorSendEventMetadata,
+    // Extending Azure response with additional information relevant for vector send event logs
+    pub event_log_metadata: VectorEventLogSendMetadata,
 }
 
 impl DriverResponse for AzureBlobResponse {

--- a/src/sinks/azure_common/service.rs
+++ b/src/sinks/azure_common/service.rs
@@ -11,8 +11,6 @@ use tracing::Instrument;
 
 use crate::sinks::{
     azure_common::config::{AzureBlobRequest, AzureBlobResponse},
-    util::vector_event::VectorSendEventMetadata,
-    util::vector_event::extract_topic_name,
 };
 
 #[derive(Clone)]
@@ -52,15 +50,6 @@ impl Service<AzureBlobRequest> for AzureBlobService {
                 Some(encoding) => blob.content_encoding(encoding),
                 None => blob,
             };
-            let topic_name = extract_topic_name(&request.metadata.partition_key);
-
-            let send_event_metadata = VectorSendEventMetadata {
-                bytes: byte_size,
-                events_len: request.metadata.count,
-                blob: request.metadata.partition_key.clone(),
-                container: request.metadata.container_name.clone(),
-                topic: topic_name,
-            };
 
             let result = blob
                 .into_future()
@@ -74,7 +63,7 @@ impl Service<AzureBlobRequest> for AzureBlobService {
                     .request_metadata
                     .into_events_estimated_json_encoded_byte_size(),
                 byte_size,
-                send_event_metadata,
+                event_log_metadata: request.metadata.event_log_metadata,
             })
         })
     }

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -19,8 +19,7 @@ use super::config::S3Options;
 use super::partitioner::S3PartitionKey;
 
 use crate::sinks::{
-    util::vector_event::VectorSendEventMetadata,
-    util::vector_event::extract_topic_name,
+    util::vector_event::VectorEventLogSendMetadata
 };
 
 #[derive(Debug, Clone)]
@@ -55,13 +54,15 @@ pub struct S3Metadata {
     pub s3_key: String,
     pub count: usize,
     pub finalizers: EventFinalizers,
+    // Specify additional information relevant for vector send event logs
+    pub event_log_metadata: VectorEventLogSendMetadata,
 }
 
 #[derive(Debug)]
 pub struct S3Response {
     pub events_byte_size: GroupedCountByteSize,
     // Extending S3 response with additional information relevant for vector send event logs
-    pub send_event_metadata: VectorSendEventMetadata,
+    pub event_log_metadata: VectorEventLogSendMetadata,
 }
 
 impl DriverResponse for S3Response {
@@ -130,15 +131,8 @@ impl Service<S3Request> for S3Service {
         let events_byte_size = request
             .request_metadata
             .into_events_estimated_json_encoded_byte_size();
-            let topic_name = extract_topic_name(&request.metadata.s3_key);
 
-        let send_event_metadata = VectorSendEventMetadata {
-            bytes: request.body.len(),
-            events_len: request.metadata.count,
-            blob: request.metadata.s3_key.clone(),
-            container: request.bucket.clone(),
-            topic: topic_name,
-        };
+        let event_log_metadata = request.metadata.event_log_metadata;
 
         let client = self.client.clone();
 
@@ -165,7 +159,7 @@ impl Service<S3Request> for S3Service {
 
             result.map(|_| S3Response {
                 events_byte_size,
-                send_event_metadata
+                event_log_metadata
             })
         })
     }

--- a/src/sinks/util/vector_event.rs
+++ b/src/sinks/util/vector_event.rs
@@ -1,42 +1,151 @@
 // Structs used for our vector event logs
 use regex::Regex;
 
+use std::collections::HashMap;
+use std::env;
+use once_cell::sync::OnceCell;
+use serde_json;
+
+use crate::event::Event;
+use crate::event::LogEvent;
+
+use crate::vector_lib::ByteSizeOf;
+
+pub static EVENT_LOG_METADATA_FIELD: OnceCell<String> = OnceCell::new();
+pub static EVENT_LOG_GRANULARITY_FIELDS: OnceCell<Vec<String>> = OnceCell::new();
+
+// Where we can find the log metadata object
+pub fn get_event_log_metadata_field() -> &'static String {
+    // Initialize the static variable once, or return the value if it's already initialized/computed
+    EVENT_LOG_METADATA_FIELD.get_or_init(|| {
+            env::var("EVENT_LOG_METADATA_FIELD").unwrap_or_else(|_| "".to_string())
+        }
+    )
+}
+
+// Within the log metadata object itself, these are fields we care to parse for
+pub fn get_event_log_granularity_fields() -> &'static Vec<String> {
+    // Initialize the static variable once, or return the value if it's already initialized/computed
+    EVENT_LOG_GRANULARITY_FIELDS.get_or_init(|| {
+            let vec_string: String = env::var("EVENT_LOG_GRANULARITY_FIELDS").unwrap_or_else(|_| "".to_string());
+            let keys: Vec<String> = serde_json::from_str(&vec_string).unwrap_or(Vec::new());
+            keys
+        }
+    )
+}
+
+/*
+* Struct to help track the count/size of events per unique combination of specified fields
+*/
+#[derive(Clone, Debug)]
+pub struct MetadataValuesCount {
+    pub value_map: HashMap<String, String>,
+    pub count: usize,
+    pub size: usize,
+}
+
 // Struct for vector send events (sending, uploaded)
 #[derive(Clone, Debug)]
-pub struct VectorSendEventMetadata {
+pub struct VectorEventLogSendMetadata {
     pub bytes: usize,
     pub events_len: usize,
     pub blob: String,
     pub container: String,
-    pub topic: String,
+    // Count map here allows us to keep track of the count/size of events per combination of fields
+    // Key is a string encoding those combinations for ease of update
+    pub count_map: HashMap<String, MetadataValuesCount>,
 }
 
-impl VectorSendEventMetadata {
+impl VectorEventLogSendMetadata {
     pub fn emit_upload_event(&self) {
-        info!(
-            message = "Uploaded events.",
-            bytes = self.bytes,
-            events_len = self.events_len,
-            blob = self.blob,
-            container = self.container,
-            topic = self.topic,
-            // VECTOR_UPLOADED_MESSAGES_EVENT
-            vector_event_type = 4
-        );
+        // VECTOR_UPLOADED_MESSAGES_EVENT
+        self.emit_count_map("Uploaded events.", 4)
     }
 
     pub fn emit_sending_event(&self) {
-        info!(
-            message = "Sending events.",
-            bytes = self.bytes,
-            events_len = self.events_len,
-            blob = self.blob,
-            container = self.container,
-            topic = self.topic,
-            // VECTOR_SENDING_MESSAGES_EVENT
-            vector_event_type = 3
-        );
+        // VECTOR_SENDING_MESSAGES_EVENT
+        self.emit_count_map("Sending events.", 3)
     }
+
+    fn emit_count_map(&self, message: &str, event_type: usize) {
+        for (_, value) in &self.count_map {
+            info!(
+                message = message,
+                keys = serde_json::to_string(&value.value_map).unwrap(),
+                bytes = value.size,
+                events_len = value.count,
+                blob = self.blob,
+                container = self.container,
+                vector_event_type = event_type,
+            );
+        }
+    }
+}
+
+// Function to get the events of a desired field and encode them in a key so we more easily keep
+// a map tracking size / count per unique combination of field values
+fn build_key(event: &LogEvent) -> String {
+    let mut key_vals: Vec<String> = Vec::new();
+    // Get the field that holds the metadata struct itself
+    let field = get_event_log_metadata_field();
+    for key_part in get_event_log_granularity_fields() {
+        if let Ok(value) = event.parse_path_and_get_value(format!("{}.{}", field, key_part)) {
+            if let Some(val) = value {
+               key_vals.push(format!("{}={}", key_part, val.to_string()));
+            }
+        }
+    }
+    key_vals.join("/")
+}
+
+// Creates a map with the values of the desired fields (i.e. {plane: PLANE_CONTROL})
+fn build_map(event: &LogEvent) -> HashMap<String, String> {
+   let mut val_map = HashMap::new();
+   let field = get_event_log_metadata_field();
+   for key_part in get_event_log_granularity_fields() {
+       if let Ok(value) = event.parse_path_and_get_value(format!("{}.{}", field, key_part)) {
+           if let Some(val) = value {
+              // Remove extra quotes from string
+              val_map.insert(key_part.to_string(), val.to_string().replace("\"", ""));
+           }
+       }
+   }
+   val_map
+}
+
+/*
+* On a list of events, iterate through them and track the counts per unique combination of
+* specified fields
+*
+* The map here is String -> MetadataValuesCount
+* where the String is an encoded key of the combination and values
+* and MetadataValuesCount is a struct that holds the count, size, and a map of the values
+*/
+pub fn generate_count_map(events: &Vec<Event>) -> HashMap<String, MetadataValuesCount> {
+    let mut count_map = HashMap::new();
+    for event in events {
+        // Check if it's a log event (see enum defined in lib/vector-core/src/event/mod.rs)
+        if let Event::Log(log_event) = event {
+            count_map.entry(build_key(log_event))
+                .and_modify(
+                    |x: &mut MetadataValuesCount| {
+                        x.count += 1;
+                        // For now, using pre-defined allocated bytes measure for size of event
+                        // This may not be fully consistent with the real size of logs
+                        // But having this a placeholder as consistent size measurement is tricky
+                        x.size += log_event.size_of();
+                    }
+                )
+                .or_insert(
+                    MetadataValuesCount {
+                        value_map: build_map(log_event),
+                        count: 1,
+                        size: 0,
+                    }
+                );
+        }
+    }
+    count_map
 }
 
 // Utility function for extracting the topic name from an archived log file path.
@@ -47,7 +156,7 @@ pub fn extract_topic_name(file_path: &str) -> String {
     let topic_capture = topic_regex.captures(file_path);
     if !topic_capture.is_none() {
         return topic_capture.unwrap()[1].to_string();
-        
+
     }
     return "".to_string();
 }


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Adding functionality into vector to build more detailed breakdowns for sink send event logs

This is done by breaking down events via the specified dimensions in the environment variables (using environment variables as a first implementation while ensuring we can use the same code to parse fields regardless of the component)

Also doing some refactoring as 1) the previous instrumentation points didn't have access to the list of events we wish to iterate over and 2) improve on the naming so we can isolate these as event log changes