### PR TITLE
Add some basic metric to track metric latency and count

### DIFF
--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -19,3 +19,8 @@ vector-common = { path = "../vector-common", features = ["btreemap"] }
 
 [build-dependencies]
 prost-build = "0.12"
+
+[dependencies.tracing]
+version = "0.1"
+default-features = false
+features = []

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -5,6 +5,8 @@ use chrono::{DateTime, TimeZone, Utc};
 use vector_lib::prometheus::parser::proto;
 use vector_lib::prometheus::parser::{GroupKind, MetricGroup, ParserError};
 
+use metrics::{counter, histogram};
+
 use crate::event::{
     metric::{Bucket, Metric, MetricKind, MetricTags, MetricValue, Quantile},
     Event,
@@ -61,6 +63,10 @@ fn reparse_groups(
                 for (key, metric) in metrics {
                     let tags = combine_tags(key.labels, tag_overrides.clone());
 
+                    let shard_name = tags.get("shardName").unwrap_or("unknown").to_string();
+                    let latency_seconds = (start - utc_timestamp(key.timestamp, start)).num_milliseconds() as f64 / 1000.0;
+                    record_metrics(latency_seconds, shard_name, "counter".to_string());
+
                     let counter = Metric::new(
                         group.name.clone(),
                         metric_kind,
@@ -77,6 +83,10 @@ fn reparse_groups(
             GroupKind::Gauge(metrics) | GroupKind::Untyped(metrics) => {
                 for (key, metric) in metrics {
                     let tags = combine_tags(key.labels, tag_overrides.clone());
+
+                    let shard_name = tags.get("shardName").unwrap_or("unknown").to_string();
+                    let latency_seconds = (start - utc_timestamp(key.timestamp, start)).num_milliseconds() as f64 / 1000.0;
+                    record_metrics(latency_seconds, shard_name, "gauge".to_string());
 
                     let gauge = Metric::new(
                         group.name.clone(),
@@ -95,6 +105,10 @@ fn reparse_groups(
             GroupKind::Histogram(metrics) => {
                 for (key, metric) in metrics {
                     let tags = combine_tags(key.labels, tag_overrides.clone());
+
+                    let shard_name = tags.get("shardName").unwrap_or("unknown").to_string();
+                    let latency_seconds = (start - utc_timestamp(key.timestamp, start)).num_milliseconds() as f64 / 1000.0;
+                    record_metrics(latency_seconds, shard_name, "histogram".to_string());
 
                     let mut buckets = metric.buckets;
                     buckets.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
@@ -133,6 +147,10 @@ fn reparse_groups(
             GroupKind::Summary(metrics) => {
                 for (key, metric) in metrics {
                     let tags = combine_tags(key.labels, tag_overrides.clone());
+
+                    let shard_name = tags.get("shardName").unwrap_or("unknown").to_string();
+                    let latency_seconds = (start - utc_timestamp(key.timestamp, start)).num_milliseconds() as f64 / 1000.0;
+                    record_metrics(latency_seconds, shard_name, "summary".to_string());
 
                     result.push(
                         Metric::new(
@@ -174,6 +192,11 @@ fn combine_tags(
     }
 
     tags
+}
+
+fn record_metrics(latency_seconds: f64, shard_name: String, metric_type: String) {
+    counter!("metric_type_count_total", 1, "metric_type" => metric_type);
+    histogram!("metric_latency_seconds", latency_seconds, "sourceShardName" => shard_name);
 }
 
 #[cfg(test)]

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -196,7 +196,7 @@ fn combine_tags(
 
 fn record_metrics(latency_seconds: f64, shard_name: String, metric_type: String) {
     counter!("metric_type_count_total", 1, "metric_type" => metric_type);
-    histogram!("metric_latency_seconds", latency_seconds, "sourceShardName" => shard_name);
+    histogram!("metric_latency_seconds", latency_seconds, "source_shard_name" => shard_name);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
Improve visibility in vector metric path

* Add counter metric to understand the metric type also when log warn if metric type is wrong. 
* add latency for metric write from obs-agent to understand the delay, this can be identified by shardName

count type:
![Screenshot 2024-09-25 at 12 21 44 PM](https://github.com/user-attachments/assets/bc66c34d-c281-4d39-97e8-84bf24d83adc)
latency:
![Screenshot 2024-09-25 at 12 21 52 PM](https://github.com/user-attachments/assets/30b49579-3ce5-4a25-b0e1-a53b19eb5022)
