### PR TITLE
Anil db/v0.39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vector"
-version = "0.39.0-databricks-v1"
+version = "0.39.0-databricks-v2"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2021"
 description = "A lightweight and ultra-fast tool for building observability pipelines"

--- a/README.databricks.md
+++ b/README.databricks.md
@@ -10,3 +10,4 @@ This lists custom changes merged in Databricks fork of Vector.
 9. Provide an option to override the Content-Encoding header for files uploaded by Google Cloud Storage sink https://github.com/databricks/vector/pull/30
 10. Add functionality to derive topic from file upload path https://github.com/databricks/vector/pull/33
 11. Update event logs to support emitting granular upload events https://github.com/databricks/vector/pull/35
+12. Add support for SNI. A PR for upstream is also been created. https://github.com/databricks/vector/pull/39 upstream PR: https://github.com/vectordotdev/vector/pull/21365

--- a/lib/vector-core/src/tls/mod.rs
+++ b/lib/vector-core/src/tls/mod.rs
@@ -183,13 +183,13 @@ pub fn tls_connector_builder(settings: &MaybeTlsSettings) -> Result<SslConnector
 }
 
 fn tls_connector(settings: &MaybeTlsSettings) -> Result<ConnectConfiguration> {
-    let verify_hostname = settings
-        .tls()
-        .map_or(true, |settings| settings.verify_hostname);
-    let configure = tls_connector_builder(settings)?
+    let mut configure = tls_connector_builder(settings)?
         .build()
         .configure()
-        .context(TlsBuildConnectorSnafu)?
-        .verify_hostname(verify_hostname);
+        .context(TlsBuildConnectorSnafu)?;
+    let tls_setting = settings.tls().cloned();
+    if let Some(tls_setting) = &tls_setting {
+        tls_setting.apply_connect_configuration(&mut configure)
+    }
     Ok(configure)
 }

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -344,16 +344,13 @@ impl TlsSettings {
     }
 
     pub fn apply_connect_configuration(&self, connection: &mut ConnectConfiguration) {
-        match &self.server_name {
-            None => connection.set_verify_hostname(self.verify_hostname),
-            Some(server_name)  => {
-                // Prevent native TLS lib from inferring default SNI using domain name from url.
-                connection.set_verify_hostname(false);
-                connection.set_use_server_name_indication(false);
-                match connection.set_hostname(server_name) {
-                    Ok(_) => (),
-                    Err(e) => error!("Failed to set server name indication: {}", e),
-                }
+        connection.set_verify_hostname(self.verify_hostname);
+        if let Some(server_name) = &self.server_name {
+            // Prevent native TLS lib from inferring default SNI using domain name from url.
+            connection.set_use_server_name_indication(false);
+            match connection.set_hostname(server_name) {
+                Ok(_) => (),
+                Err(e) => error!("Failed to set server name indication: {}", e),
             }
         }
     }

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -148,6 +148,14 @@ pub struct TlsConfig {
     #[configurable(metadata(docs::examples = "PassWord1"))]
     #[configurable(metadata(docs::human_name = "Key File Password"))]
     pub key_pass: Option<String>,
+
+    /// Server name to use when using Server Name Indication (SNI).
+    ///
+    /// Only relevant for outgoing connections.
+    #[serde(alias = "server_name")]
+    #[configurable(metadata(docs::examples = "www.example.com"))]
+    #[configurable(metadata(docs::human_name = "Server Name"))]
+    pub server_name: Option<String>,
 }
 
 impl TlsConfig {
@@ -169,6 +177,7 @@ pub struct TlsSettings {
     authorities: Vec<X509>,
     pub(super) identity: Option<IdentityStore>, // openssl::pkcs12::ParsedPkcs12 doesn't impl Clone yet
     alpn_protocols: Option<Vec<u8>>,
+    server_name: Option<String>,
 }
 
 #[derive(Clone)]
@@ -203,6 +212,7 @@ impl TlsSettings {
             authorities: options.load_authorities()?,
             identity: options.load_identity()?,
             alpn_protocols: options.parse_alpn_protocols()?,
+            server_name: options.server_name.clone(),
         })
     }
 
@@ -334,7 +344,18 @@ impl TlsSettings {
     }
 
     pub fn apply_connect_configuration(&self, connection: &mut ConnectConfiguration) {
-        connection.set_verify_hostname(self.verify_hostname);
+        match &self.server_name {
+            None => connection.set_verify_hostname(self.verify_hostname),
+            Some(server_name)  => {
+                // Prevent native TLS lib from inferring default SNI using domain name from url.
+                connection.set_verify_hostname(false);
+                connection.set_use_server_name_indication(false);
+                match connection.set_hostname(server_name) {
+                    Ok(_) => (),
+                    Err(e) => error!("Failed to set server name indication: {}", e),
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
 an upstream pull has also been created https://github.com/vectordotdev/vector/pull/21365


we have a usecase where server is behind a reverse proxy and it selects the right backend based on SNI provided.

This PR adds options to set SNI which sending to other IP/domain. this unblocks the nephos use case where we can use local envoy to connect VA.



test configuration:
```
{
    "sinks": {
	    "grpc_aggregator": {
            "address": "https://127.0.0.1:443",
            "inputs": [
                "http"
            ],
            "tls": {
	        "ca_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/testCA.pem",
                "crt_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostcrt.pem",
                "key_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostkey.pem",	    
                "enabled": true,
                "verify_certificate": true,
                "verify_hostname": false,
		"server_name": "www.example.com"
            },
            "type": "vector"
        },
	    "aggregator": {
            "uri": "https://127.0.0.1:444",
	    "encoding": {
                  "codec": "json"             },
            "inputs": [
                "http"
            ],
            "tls": {
                "ca_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/testCA.pem",
                "crt_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostcrt.pem",
                "key_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostkey.pem",
                "verify_certificate": true,
                "verify_hostname": false,
		"server_name": "www.example.com"
            },
            "type": "http"
        },
	"print": {
            "encoding": {
                "codec": "json"
            },
            "inputs": [
                "http2",
		"agent"
            ],
            "type": "console"
        }
    },
    "sources": {
	"agent": {
            "address": "0.0.0.0:443",
            "tls": {
                "alpn_protocols": [
                    "h2"
                ],
		"ca_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/testCA.pem",
                "crt_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostcrt.pem",
                "enabled": true,
                "key_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostkey.pem",
                "verify_certificate": true,
                "verify_hostname": false
            },
            "type": "vector"
        },
        "http": {
            "address": "0.0.0.0:6000",
            "framing": {
                "method": "bytes"
            },
            "headers": [

            ],
            "keepalive": {
                "max_connection_age_secs": 300
            },
            "strict_path": false,
            "tls": {
                "alpn_protocols": [
                    "h2"
                ],
                "ca_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/testCA.pem",
                "crt_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostcrt.pem",
                "enabled": true,
                "key_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostkey.pem",
                "verify_certificate": false
            },
            "type": "http_server"
        },
	"http2": {
            "address": "0.0.0.0:444",
            "framing": {
                "method": "bytes"
            },
            "headers": [

            ],
            "keepalive": {
                "max_connection_age_secs": 300
            },
            "strict_path": false,
            "tls": {
                "alpn_protocols": [
                    "h2"
                ],
                "ca_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/testCA.pem",
                "crt_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostcrt.pem",
                "enabled": true,
                "key_file": "/Users/anil.gupta/universe/woodchuck/regtests/resources/localhostkey.pem",
                "verify_certificate": false
            },
            "type": "http_server"
        }
    }
}
```

sent log data to http source using  `curl -k "https://localhost:6000" -d "hi"`
and captured client hello frame from wrieshark on triggered by http sink and other triggered by vector sink

<img width="1725" alt="Screenshot 2024-09-26 at 10 34 13 PM" src="https://github.com/user-attachments/assets/de4fcd2b-883c-4851-85e7-9fbb74e73594">
<img width="1728" alt="Screenshot 2024-09-26 at 10 34 19 PM" src="https://github.com/user-attachments/assets/b92c7ed7-3b0e-4597-a061-021d91a0ac4f">
